### PR TITLE
Address user-feedback regarding fastp version and I/O file naming 

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -17,7 +17,7 @@
                     },
                     "fastp": {
                         "branch": "master",
-                        "git_sha": "37a98dd100d74d9188a272197663587de1331a0e",
+                        "git_sha": "d9ec4ef289ad39b8a662a7a12be50409b11df84b",
                         "installed_by": ["modules"]
                     },
                     "fastqc": {

--- a/modules/local/python/seq_cleaner.nf
+++ b/modules/local/python/seq_cleaner.nf
@@ -12,7 +12,7 @@ process PYTHON_SEQ_CLEANER {
     tuple val(meta), path(input_fasta)
 
     output:
-    tuple val(meta), path("${prefix}.fasta")             , emit: cleaned_fasta
+    tuple val(meta), path("*cleaned.fasta")             , emit: cleaned_fasta
     path "versions.yml"                                  , emit: versions
 
     when:
@@ -24,7 +24,7 @@ process PYTHON_SEQ_CLEANER {
     def local_min_valid_percentage = (100 - params.max_missing_percentage)
 
     """
-    seq_cleaner.py -f ${local_min_valid_percentage} $input_fasta ${prefix}.fasta
+    seq_cleaner.py -f ${local_min_valid_percentage} $input_fasta ${prefix}.cleaned.fasta
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/fastp/environment.yml
+++ b/modules/nf-core/fastp/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/fastp
+  - bioconda::fastp=1.0.1

--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -2,14 +2,14 @@ process FASTP {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::fastp=0.23.3"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastp:0.23.3--h5f740d0_0' :
-        'quay.io/biocontainers/fastp:0.23.3--h5f740d0_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/527b18847a97451091dba07a886b24f17f742a861f9f6c9a6bfb79d4f1f3bf9d/data' :
+        'community.wave.seqera.io/library/fastp:1.0.1--c8b87fe62dcc103c' }"
 
     input:
-    tuple val(meta), path(reads)
-    path  adapter_fasta
+    tuple val(meta), path(reads), path(adapter_fasta)
+    val   discard_trimmed_pass
     val   save_trimmed_fail
     val   save_merged
 
@@ -18,9 +18,9 @@ process FASTP {
     tuple val(meta), path('*.json')           , emit: json
     tuple val(meta), path('*.html')           , emit: html
     tuple val(meta), path('*.log')            , emit: log
-    path "versions.yml"                       , emit: versions
     tuple val(meta), path('*.fail.fastq.gz')  , optional:true, emit: reads_fail
     tuple val(meta), path('*.merged.fastq.gz'), optional:true, emit: reads_merged
+    path "versions.yml"                       , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,7 +29,9 @@ process FASTP {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def adapter_list = adapter_fasta ? "--adapter_fasta ${adapter_fasta}" : ""
-    def fail_fastq = save_trimmed_fail && meta.single_end ? "--failed_out ${prefix}.fail.fastq.gz" : save_trimmed_fail && !meta.single_end ? "--unpaired1 ${prefix}_1.fail.fastq.gz --unpaired2 ${prefix}_2.fail.fastq.gz" : ''
+    def fail_fastq = save_trimmed_fail && meta.single_end ? "--failed_out ${prefix}.fail.fastq.gz" : save_trimmed_fail && !meta.single_end ? "--failed_out ${prefix}.paired.fail.fastq.gz --unpaired1 ${prefix}_1.fail.fastq.gz --unpaired2 ${prefix}_2.fail.fastq.gz" : ''
+    def out_fq1 = discard_trimmed_pass ?: ( meta.single_end ? "--out1 ${prefix}.fastp.fastq.gz" : "--out1 ${prefix}_1.fastp.fastq.gz" )
+    def out_fq2 = discard_trimmed_pass ?: "--out2 ${prefix}_2.fastp.fastq.gz"
     // Added soft-links to original fastqs for consistent naming in MultiQC
     // Use single ended for interleaved. Add --interleaved_in in config.
     if ( task.ext.args?.contains('--interleaved_in') ) {
@@ -45,7 +47,7 @@ process FASTP {
             $adapter_list \\
             $fail_fastq \\
             $args \\
-            2> ${prefix}.fastp.log \\
+            2>| >(tee ${prefix}.fastp.log >&2) \\
         | gzip -c > ${prefix}.fastp.fastq.gz
 
         cat <<-END_VERSIONS > versions.yml
@@ -59,14 +61,14 @@ process FASTP {
 
         fastp \\
             --in1 ${prefix}.fastq.gz \\
-            --out1  ${prefix}.fastp.fastq.gz \\
+            $out_fq1 \\
             --thread $task.cpus \\
             --json ${prefix}.fastp.json \\
             --html ${prefix}.fastp.html \\
             $adapter_list \\
             $fail_fastq \\
             $args \\
-            2> ${prefix}.fastp.log
+            2>| >(tee ${prefix}.fastp.log >&2)
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -81,8 +83,8 @@ process FASTP {
         fastp \\
             --in1 ${prefix}_1.fastq.gz \\
             --in2 ${prefix}_2.fastq.gz \\
-            --out1 ${prefix}_1.fastp.fastq.gz \\
-            --out2 ${prefix}_2.fastp.fastq.gz \\
+            $out_fq1 \\
+            $out_fq2 \\
             --json ${prefix}.fastp.json \\
             --html ${prefix}.fastp.html \\
             $adapter_list \\
@@ -91,7 +93,7 @@ process FASTP {
             --thread $task.cpus \\
             --detect_adapter_for_pe \\
             $args \\
-            2> ${prefix}.fastp.log
+            2>| >(tee ${prefix}.fastp.log >&2)
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -99,4 +101,24 @@ process FASTP {
         END_VERSIONS
         """
     }
+
+    stub:
+    def prefix              = task.ext.prefix ?: "${meta.id}"
+    def is_single_output    = task.ext.args?.contains('--interleaved_in') || meta.single_end
+    def touch_reads         = (discard_trimmed_pass) ? "" : (is_single_output) ? "echo '' | gzip > ${prefix}.fastp.fastq.gz" : "echo '' | gzip > ${prefix}_1.fastp.fastq.gz ; echo '' | gzip > ${prefix}_2.fastp.fastq.gz"
+    def touch_merged        = (!is_single_output && save_merged) ? "echo '' | gzip >  ${prefix}.merged.fastq.gz" : ""
+    def touch_fail_fastq    = (!save_trimmed_fail) ? "" : meta.single_end ? "echo '' | gzip > ${prefix}.fail.fastq.gz" : "echo '' | gzip > ${prefix}.paired.fail.fastq.gz ; echo '' | gzip > ${prefix}_1.fail.fastq.gz ; echo '' | gzip > ${prefix}_2.fail.fastq.gz"
+    """
+    $touch_reads
+    $touch_fail_fastq
+    $touch_merged
+    touch "${prefix}.fastp.json"
+    touch "${prefix}.fastp.html"
+    touch "${prefix}.fastp.log"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        fastp: \$(fastp --version 2>&1 | sed -e "s/fastp //g")
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/fastp/meta.yml
+++ b/modules/nf-core/fastp/meta.yml
@@ -11,63 +11,117 @@ tools:
       documentation: https://github.com/OpenGene/fastp
       doi: 10.1093/bioinformatics/bty560
       licence: ["MIT"]
+      identifier: biotools:fastp
 input:
-  - meta:
-      type: map
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information. Use 'single_end: true' to specify single ended or interleaved FASTQs. Use 'single_end: false' for paired-end reads.
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively. If you wish to run interleaved paired-end data,  supply as single-end data
+          but with `--interleaved_in` in your `modules.conf`'s `ext.args` for the module.
+        ontologies: []
+    - adapter_fasta:
+        type: file
+        description: File in FASTA format containing possible adapters to remove.
+        pattern: "*.{fasta,fna,fas,fa}"
+        ontologies: []
+  - discard_trimmed_pass:
+      type: boolean
       description: |
-        Groovy Map containing sample information. Use 'single_end: true' to specify single ended or interleaved FASTQs. Use 'single_end: false' for paired-end reads.
-        e.g. [ id:'test', single_end:false ]
-  - reads:
-      type: file
-      description: |
-        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
-        respectively. If you wish to run interleaved paired-end data,  supply as single-end data
-        but with `--interleaved_in` in your `modules.conf`'s `ext.args` for the module.
-  - adapter_fasta:
-      type: file
-      description: File in FASTA format containing possible adapters to remove.
-      pattern: "*.{fasta,fna,fas,fa}"
+        Specify true to not write any reads that pass trimming thresholds.
+        This can be used to use fastp for the output report only.
   - save_trimmed_fail:
       type: boolean
-      description: Specify true to save files that failed to pass trimming thresholds ending in `*.fail.fastq.gz`
+      description: Specify true to save files that failed to pass trimming thresholds
+        ending in `*.fail.fastq.gz`
   - save_merged:
       type: boolean
-      description: Specify true to save all merged reads to the a file ending in `*.merged.fastq.gz`
-
+      description: Specify true to save all merged reads to a file ending in `*.merged.fastq.gz`
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - reads:
-      type: file
-      description: The trimmed/modified/unmerged fastq reads
-      pattern: "*fastp.fastq.gz"
-  - json:
-      type: file
-      description: Results in JSON format
-      pattern: "*.json"
-  - html:
-      type: file
-      description: Results in HTML format
-      pattern: "*.html"
-  - log:
-      type: file
-      description: fastq log file
-      pattern: "*.log"
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
-  - reads_fail:
-      type: file
-      description: Reads the failed the preprocessing
-      pattern: "*fail.fastq.gz"
-  - reads_merged:
-      type: file
-      description: Reads that were successfully merged
-      pattern: "*.{merged.fastq.gz}"
+  reads:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fastp.fastq.gz":
+          type: file
+          description: The trimmed/modified/unmerged fastq reads
+          pattern: "*fastp.fastq.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  json:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.json":
+          type: file
+          description: Results in JSON format
+          pattern: "*.json"
+          ontologies:
+            - edam: http://edamontology.org/format_3464 # JSON
+  html:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.html":
+          type: file
+          description: Results in HTML format
+          pattern: "*.html"
+          ontologies: []
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.log":
+          type: file
+          description: fastq log file
+          pattern: "*.log"
+          ontologies: []
+  reads_fail:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fail.fastq.gz":
+          type: file
+          description: Reads the failed the preprocessing
+          pattern: "*fail.fastq.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  reads_merged:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.merged.fastq.gz":
+          type: file
+          description: Reads that were successfully merged
+          pattern: "*.{merged.fastq.gz}"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
+  - "@drpatelh"
+  - "@kevinmenden"
+maintainers:
   - "@drpatelh"
   - "@kevinmenden"

--- a/modules/nf-core/fastp/tests/main.nf.test
+++ b/modules/nf-core/fastp/tests/main.nf.test
@@ -1,0 +1,661 @@
+nextflow_process {
+
+    name "Test Process FASTP"
+    script "../main.nf"
+    process "FASTP"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "fastp"
+
+    test("test_fastp_single_end") {
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = [] // empty list for no adapter file!
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("single end (151 cycles)") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 99") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.versions).match()
+                }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end") {
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("Q30 bases: 12281(88.3716%)") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.versions).match() }
+            )
+        }
+    }
+
+    test("fastp test_fastp_interleaved") {
+
+        config './nextflow.interleaved.config'
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("paired end (151 cycles + 151 cycles)") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 162") },
+                { assert process.out.reads_fail == [] },
+                { assert process.out.reads_merged == [] },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.versions).match() }
+            )
+        }
+    }
+
+    test("test_fastp_single_end_trim_fail") {
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("single end (151 cycles)") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 99") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.versions).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_trim_fail") {
+
+        config './nextflow.save_failed.config'
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 162") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.versions).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_merged") {
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("total reads: 75") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.versions).match() },
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_merged_adapterlist") {
+
+        when {
+            process {
+                """
+                adapter_fasta        = file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true)
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = false
+                input[2] = false
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("<div id='After_filtering__merged__quality'>") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("total bases: 13683") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.versions).match() }
+            )
+        }
+    }
+
+    test("test_fastp_single_end_qc_only") {
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("single end (151 cycles)") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("reads passed filter: 99") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.reads_merged,
+                    process.out.versions).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_qc_only") {
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.html.get(0).get(1)).getText().contains("The input has little adapter percentage (~0.000000%), probably it's trimmed before.") },
+                { assert path(process.out.log.get(0).get(1)).getText().contains("Q30 bases: 12281(88.3716%)") },
+                { assert snapshot(
+                    process.out.reads,
+                    process.out.reads,
+                    process.out.reads_fail,
+                    process.out.reads_fail,
+                    process.out.reads_merged,
+                    process.out.reads_merged,
+                    process.out.versions).match() }
+            )
+        }
+    }
+
+    test("test_fastp_single_end - stub") {
+
+        options "-stub"
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end - stub") {
+
+        options "-stub"
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("fastp - stub test_fastp_interleaved") {
+
+        options "-stub"
+
+        config './nextflow.interleaved.config'
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_single_end_trim_fail - stub") {
+
+        options "-stub"
+
+        when {
+
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_trim_fail - stub") {
+
+        options "-stub"
+
+        config './nextflow.save_failed.config'
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_merged - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_merged_adapterlist - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                adapter_fasta        = file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true)
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_single_end_qc_only - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_fastp_paired_end_qc_only - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
+                ])
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/fastp/tests/main.nf.test.snap
+++ b/modules/nf-core/fastp/tests/main.nf.test.snap
@@ -1,0 +1,1250 @@
+{
+    "test_fastp_single_end_qc_only - stub": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-11T09:55:42.073182"
+    },
+    "test_fastp_paired_end": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1.fastp.fastq.gz:md5,67b2bbae47f073e05a97a9c2edce23c7",
+                        "test_2.fastp.fastq.gz:md5,25cbdca08e2083dbd4f0502de6b62f39"
+                    ]
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,c4974822658d02533e660fae343f281b"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-19T16:23:12.436191"
+    },
+    "test_fastp_paired_end_merged_adapterlist": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1.fastp.fastq.gz:md5,54b726a55e992a869fd3fa778afe1672",
+                        "test_2.fastp.fastq.gz:md5,29d3b33b869f7b63417b8ff07bb128ba"
+                    ]
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.merged.fastq.gz:md5,c873bb1ab3fa859dcc47306465e749d5"
+                ]
+            ],
+            [
+                "versions.yml:md5,c4974822658d02533e660fae343f281b"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-19T16:23:32.267735"
+    },
+    "test_fastp_single_end_qc_only": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,c4974822658d02533e660fae343f281b"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-19T16:23:36.149003"
+    },
+    "test_fastp_paired_end_trim_fail": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1.fastp.fastq.gz:md5,6ff32a64c5188b9a9192be1398c262c7",
+                        "test_2.fastp.fastq.gz:md5,db0cb7c9977e94ac2b4b446ebd017a8a"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test.paired.fail.fastq.gz:md5,409b687c734cedd7a1fec14d316e1366",
+                        "test_1.fail.fastq.gz:md5,4f273cf3159c13f79e8ffae12f5661f6",
+                        "test_2.fail.fastq.gz:md5,f97b9edefb5649aab661fbc9e71fc995"
+                    ]
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,c4974822658d02533e660fae343f281b"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-19T16:23:24.23891"
+    },
+    "fastp - stub test_fastp_interleaved": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-11T09:55:19.47199"
+    },
+    "test_fastp_single_end - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-11T09:55:09.617001"
+    },
+    "test_fastp_paired_end_merged_adapterlist - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "6": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-11T09:55:37.413738"
+    },
+    "test_fastp_paired_end_merged - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "6": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-11T09:55:32.965652"
+    },
+    "test_fastp_paired_end_merged": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1.fastp.fastq.gz:md5,54b726a55e992a869fd3fa778afe1672",
+                        "test_2.fastp.fastq.gz:md5,29d3b33b869f7b63417b8ff07bb128ba"
+                    ]
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.merged.fastq.gz:md5,c873bb1ab3fa859dcc47306465e749d5"
+                ]
+            ],
+            [
+                "versions.yml:md5,c4974822658d02533e660fae343f281b"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-19T16:23:28.074624"
+    },
+    "test_fastp_paired_end - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-11T09:55:14.414258"
+    },
+    "test_fastp_single_end": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastp.fastq.gz:md5,67b2bbae47f073e05a97a9c2edce23c7"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,c4974822658d02533e660fae343f281b"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-19T16:23:08.469846"
+    },
+    "test_fastp_single_end_trim_fail - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "reads_fail": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-11T09:55:23.871395"
+    },
+    "test_fastp_paired_end_trim_fail - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.paired.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_1.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fastp.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "reads_fail": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.paired.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_1.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.fail.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-11T09:55:28.399328"
+    },
+    "fastp test_fastp_interleaved": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastp.fastq.gz:md5,217d62dc13a23e92513a1bd8e1bcea39"
+                ]
+            ],
+            [
+                "versions.yml:md5,c4974822658d02533e660fae343f281b"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-19T16:23:16.479494"
+    },
+    "test_fastp_single_end_trim_fail": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fastp.fastq.gz:md5,67b2bbae47f073e05a97a9c2edce23c7"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.fail.fastq.gz:md5,3e4aaadb66a5b8fc9b881bf39c227abd"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,c4974822658d02533e660fae343f281b"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-19T16:23:20.299076"
+    },
+    "test_fastp_paired_end_qc_only": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,c4974822658d02533e660fae343f281b"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-19T16:23:40.113724"
+    },
+    "test_fastp_paired_end_qc_only - stub": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fastp.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    
+                ],
+                "reads_fail": [
+                    
+                ],
+                "reads_merged": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,c4974822658d02533e660fae343f281b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-11T09:55:46.696419"
+    }
+}

--- a/modules/nf-core/fastp/tests/nextflow.interleaved.config
+++ b/modules/nf-core/fastp/tests/nextflow.interleaved.config
@@ -1,0 +1,5 @@
+process {
+    withName: FASTP {
+        ext.args = "--interleaved_in -e 30"
+    }
+}

--- a/modules/nf-core/fastp/tests/nextflow.save_failed.config
+++ b/modules/nf-core/fastp/tests/nextflow.save_failed.config
@@ -1,0 +1,5 @@
+process {
+    withName: FASTP {
+        ext.args = "-e 30"
+    }
+}

--- a/subworkflows/local/quality_control.nf
+++ b/subworkflows/local/quality_control.nf
@@ -13,7 +13,7 @@ workflow QUALITY_CONTROL_WF {
 
         ch_fastp_in = reads_ch.map { meta, files -> [meta, files, []] }
 
-        FASTP(reads_ch, [], false, false)
+        FASTP(ch_fastp_in, [], false, false)
 
     emit:
         trimmed_reads = FASTP.out.reads

--- a/subworkflows/local/quality_control.nf
+++ b/subworkflows/local/quality_control.nf
@@ -11,6 +11,8 @@ workflow QUALITY_CONTROL_WF {
 
         FASTQC(reads_ch)
 
+        ch_fastp_in = reads_ch.map { meta, files -> [meta, files, []] }
+
         FASTP(reads_ch, [], false, false)
 
     emit:

--- a/subworkflows/local/quality_control.nf
+++ b/subworkflows/local/quality_control.nf
@@ -13,7 +13,7 @@ workflow QUALITY_CONTROL_WF {
 
         ch_fastp_in = reads_ch.map { meta, files -> [meta, files, []] }
 
-        FASTP(ch_fastp_in, true, false, false)
+        FASTP(ch_fastp_in, false, false, false)
 
     emit:
         trimmed_reads = FASTP.out.reads

--- a/subworkflows/local/quality_control.nf
+++ b/subworkflows/local/quality_control.nf
@@ -13,7 +13,7 @@ workflow QUALITY_CONTROL_WF {
 
         ch_fastp_in = reads_ch.map { meta, files -> [meta, files, []] }
 
-        FASTP(ch_fastp_in, [], false, false)
+        FASTP(ch_fastp_in, true, false, false)
 
     emit:
         trimmed_reads = FASTP.out.reads


### PR DESCRIPTION
This pull request updates the `fastp` module to use version 1.0.1, improves flexibility in output handling, and enhances metadata and documentation for better interoperability and clarity. The changes affect the module's configuration, environment, process logic, and metadata files, as well as add new test configurations.

**Key changes include:**

### fastp Module Version and Environment Updates
- Updated the `fastp` dependency to version 1.0.1 in both `modules.json` and by introducing a new `environment.yml` file, ensuring the module uses the latest features and bug fixes. The conda and container image references in `main.nf` were also updated accordingly. [[1]](diffhunk://#diff-97c7fe3fe8f628d2435d00b93af4cb47052e8e1f3d33b7334d1a031fd15415d7L20-R20) [[2]](diffhunk://#diff-0a0b43ddbd184f77bf36406ba201b0891d3d1726f59f3cf13924f975ef56f285R1-R8) [[3]](diffhunk://#diff-fa4f6ef1f7da404f2a2b05beb0559156690017c2e541573796bc10bf10a43596L5-R12)

### Process and Output Handling Improvements
- Refactored the `FASTP` process in `main.nf` to:
  - Accept a new `discard_trimmed_pass` parameter, allowing users to skip writing reads that pass trimming (for report-only usage).
  - Refine logic for output file generation, including more flexible handling of failed and merged reads, and improved logging with `tee`.
  - Add a `stub` section for dry-run/test scenarios, ensuring all expected output files are created as empty files for workflow validation. [[1]](diffhunk://#diff-fa4f6ef1f7da404f2a2b05beb0559156690017c2e541573796bc10bf10a43596L5-R12) [[2]](diffhunk://#diff-fa4f6ef1f7da404f2a2b05beb0559156690017c2e541573796bc10bf10a43596L32-R34) [[3]](diffhunk://#diff-fa4f6ef1f7da404f2a2b05beb0559156690017c2e541573796bc10bf10a43596L48-R50) [[4]](diffhunk://#diff-fa4f6ef1f7da404f2a2b05beb0559156690017c2e541573796bc10bf10a43596L62-R71) [[5]](diffhunk://#diff-fa4f6ef1f7da404f2a2b05beb0559156690017c2e541573796bc10bf10a43596L84-R87) [[6]](diffhunk://#diff-fa4f6ef1f7da404f2a2b05beb0559156690017c2e541573796bc10bf10a43596L94-R123)

### Metadata and Documentation Enhancements
- Overhauled the `meta.yml` to:
  - Use a more structured and ontology-rich format for inputs and outputs, improving clarity and interoperability.
  - Add new fields such as `discard_trimmed_pass`, and update descriptions and ontologies for all outputs.
  - Add tool identifiers and maintainers for better documentation and discoverability. [[1]](diffhunk://#diff-7926e7a3cadfe8429844c5c413c3bc65d752c354a5020c6a7350df3d77804facR14-R16) [[2]](diffhunk://#diff-7926e7a3cadfe8429844c5c413c3bc65d752c354a5020c6a7350df3d77804facR27-R127)

### Test and Configuration Additions
- Added new test configuration files (`nextflow.interleaved.config` and `nextflow.save_failed.config`) to cover interleaved and failed-read scenarios, supporting more robust module testing. [[1]](diffhunk://#diff-930134b9a8ceb1898ab4b41219d2034e420d70e1e08707d6b48e5fe2411f2719R1-R5) [[2]](diffhunk://#diff-cc1d4723e8d75537ca3c82b06519c483627882be07af1e35f30db004c3247ddaR1-R5)

### Minor Fixes and Consistency Updates
- Adjusted the `PYTHON_SEQ_CLEANER` process to ensure output filenames end with `.cleaned.fasta`, aligning with expected naming conventions. [[1]](diffhunk://#diff-0fb5161caeb30cfd1848b0489d137fb07836e277d3b6a526a47611e44fe35568L15-R15) [[2]](diffhunk://#diff-0fb5161caeb30cfd1848b0489d137fb07836e277d3b6a526a47611e44fe35568L27-R27)

These changes collectively modernize the `fastp` module, improve its usability, and ensure better compatibility with workflow standards.